### PR TITLE
Automatically drop Pix

### DIFF
--- a/examples/low_level_ocr_full_page.rs
+++ b/examples/low_level_ocr_full_page.rs
@@ -6,12 +6,11 @@ use leptess::{leptonica, tesseract};
 fn main() {
     let mut api = tesseract::TessApi::new(None, "eng").unwrap();
 
-    let mut pix = leptonica::pix_read(Path::new("path/page.bmp")).unwrap();
+    let pix = leptonica::pix_read(Path::new("path/page.bmp")).unwrap();
     api.set_image(&pix);
 
     let text = api.get_utf8_text();
     println!("{}", text.unwrap());
 
     api.destroy();
-    pix.destroy();
 }

--- a/examples/low_level_ocr_word_by_word.rs
+++ b/examples/low_level_ocr_word_by_word.rs
@@ -6,7 +6,7 @@ use leptess::{leptonica, tesseract};
 fn main() {
     let mut api = tesseract::TessApi::new(None, "eng").unwrap();
 
-    let mut pix = leptonica::pix_read(Path::new("path/page.bmp")).unwrap();
+    let pix = leptonica::pix_read(Path::new("path/page.bmp")).unwrap();
     api.set_image(&pix);
 
     // detect bounding boxes for words
@@ -31,5 +31,4 @@ fn main() {
     }
 
     api.destroy();
-    pix.destroy();
 }

--- a/src/leptonica.rs
+++ b/src/leptonica.rs
@@ -16,8 +16,13 @@ impl Pix {
     pub fn get_h(&self) -> u32 {
         unsafe { (*self.raw).h }
     }
-    pub fn destroy(&mut self) {
-        unsafe { capi::pixDestroy(&mut self.raw) }
+}
+
+impl Drop for Pix {
+    fn drop(&mut self) {
+        unsafe {
+            capi::pixDestroy(&mut self.raw);
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,6 @@ use std::path::Path;
 
 pub struct LepTess {
     tess_api: tesseract::TessApi,
-    img: Option<leptonica::Pix>,
 }
 
 impl Drop for LepTess {
@@ -108,8 +107,7 @@ impl Drop for LepTess {
 impl LepTess {
     pub fn new(data_path: Option<&str>, lang: &str) -> Result<LepTess, tesseract::TessInitError> {
         Ok(LepTess {
-            tess_api: tesseract::TessApi::new(data_path, lang)?,
-            img: None,
+            tess_api: tesseract::TessApi::new(data_path, lang)?
         })
     }
 
@@ -122,7 +120,6 @@ impl LepTess {
         match re {
             Some(pix) => {
                 self.tess_api.set_image(&pix);
-                self.img = Some(pix);
                 true
             }
             None => false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@
 //! println!("{}", text.unwrap());
 //!
 //! api.destroy();
-//! pix.destroy();
 //! ```
 //!
 //! Raw unsafe C API [bindings](capi/index.html) are auto-generated using bindgen. To update the
@@ -103,10 +102,6 @@ pub struct LepTess {
 impl Drop for LepTess {
     fn drop(&mut self) {
         self.tess_api.destroy();
-        match self.img {
-            Some(ref mut x) => x.destroy(),
-            _ => {}
-        }
     }
 }
 
@@ -126,12 +121,6 @@ impl LepTess {
 
         match re {
             Some(pix) => {
-                match self.img {
-                    Some(ref mut x) => {
-                        x.destroy();
-                    }
-                    _ => {}
-                }
                 self.tess_api.set_image(&pix);
                 self.img = Some(pix);
                 true

--- a/tests/full_page_ocr.rs
+++ b/tests/full_page_ocr.rs
@@ -62,7 +62,7 @@ fn test_ocr_iterate_word() {
 #[test]
 fn test_low_lvl_get_text() {
     let path = Path::new("./tests/di.png");
-    let mut img = leptonica::pix_read(path).unwrap();
+    let img = leptonica::pix_read(path).unwrap();
 
     let mut api = tesseract::TessApi::new(Some("./tests/tessdata"), "eng").unwrap();
     api.set_image(&img);
@@ -80,13 +80,12 @@ fn test_low_lvl_get_text() {
     );
 
     api.destroy();
-    img.destroy();
 }
 
 #[test]
 fn test_low_lvl_ocr_iterate_word() {
     let path = Path::new("./tests/di.png");
-    let mut img = leptonica::pix_read(path).unwrap();
+    let img = leptonica::pix_read(path).unwrap();
 
     let mut api = tesseract::TessApi::new(Some("./tests/tessdata"), "eng").unwrap();
     api.set_image(&img);
@@ -123,7 +122,6 @@ fn test_low_lvl_ocr_iterate_word() {
     assert_eq!("people\n", api.get_utf8_text().unwrap());
 
     api.destroy();
-    img.destroy();
 }
 
 #[test]

--- a/tests/pix.rs
+++ b/tests/pix.rs
@@ -6,10 +6,8 @@ use leptess::leptonica;
 #[test]
 fn test_read_pix() {
     let path = Path::new("./tests/di.png");
-    let mut img = leptonica::pix_read(path).unwrap();
+    let img = leptonica::pix_read(path).unwrap();
 
     assert_eq!(442, img.get_w());
     assert_eq!(852, img.get_h());
-
-    img.destroy();
 }


### PR DESCRIPTION
This is safe to do.
Tesseract makes a copy of Pix.
https://tesseract-ocr.github.io/4.0.0/a01625.html#ga0c4c7f05fd58b3665b123232a05545ad

We therefore do not need to worry about Pix being dropped before
Tesseract.