### PR TITLE
Fix memory leak, didn't properly clean up Tess instance

### DIFF
--- a/src/tesseract.rs
+++ b/src/tesseract.rs
@@ -26,10 +26,11 @@ pub struct TessApi {
 
 impl Drop for TessApi {
     fn drop(&mut self) {
-        if !self.data_path_cptr.is_null() {
-            unsafe {
-                capi::TessBaseAPIEnd(self.raw);
-                capi::TessBaseAPIDelete(self.raw);
+        unsafe {
+            capi::TessBaseAPIEnd(self.raw);
+            capi::TessBaseAPIDelete(self.raw);
+
+            if !self.data_path_cptr.is_null() {
                 // free data_path_cptr, drop trait will take care of it
                 CString::from_raw(self.data_path_cptr);
             }


### PR DESCRIPTION
I encountered a memory leak while using `leptess`. It seems that things weren't properly cleaned up when `LepTess` was dropped.

In this PR I've attempted to fix this issue. I'm not 100% sure this change is correct, but it did fix the memory leak in my situation. Could you verify this change?

It did only drop everything when the internal `data_path_cptr` field was not null. I believe it should drop the Tess instance in all cases.

You can use the following code for testing, give it a path to an image that is 10MB or larger in size and run it. You'll see the memory usage creeping up.

```rust
fn main() {
    for _ in 0..20 {
        read_text("PATH_TO_LARGE_IMAGE");
    }
}

fn read_text(path: &str) -> Result<String, ()> {
    let mut lt = leptess::LepTess::new(None, "eng").unwrap();
    lt.set_image(path);
    lt.get_utf8_text().unwrap()
}
```

Hope this helps.

Thanks for the awesome crate! 