### PR TITLE
WIP: build docs on CI and deploy to GitHub pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,11 @@ jobs:
           name: Build all targets
           command: cargo build --all --all-targets
       - run:
-          name: Test build doc
+          name: Build doc
           command: cargo doc
+      - persist_to_workspace:
+          root: target/
+          paths: doc/
       - save_cache:
           paths:
             - /usr/local/cargo/registry
@@ -37,9 +40,30 @@ jobs:
       - run:
           name: Run all tests
           command: cargo test --all
-
+  docs-deploy:
+    docker:
+      - image: node:8.10.0
+    steps:
+      - checkout
+      - attach_workspace:
+          at: target
+      - run:
+          name: Install and configure dependencies
+          command: |
+            npm install -g --silent gh-pages@2.0.1
+            git config user.name "Qingping Hou"
+            git config user.email "dave2008713@gmail.com"
+      - run:
+          name: Deploy docs to gh-pages branch
+          command: gh-pages --dist target/doc/
 workflows:
   version: 2
   workflow:
     jobs:
       - test
+      - docs-deploy:
+          requires:
+            - test
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
_Note: this PR is not complete, it requires some changes by @houqp_

Fixes #5 

Here I've attempted to start on automatically building docs and deploying it to GitHub pages. I've used the following article as a reference from the CircleCI blog:
https://circleci.com/blog/deploying-documentation-to-github-pages-with-continuous-integration/

I've added a step for documentation deployment. The docs being built at `target/doc/` are persisted, and used for deployment. Docs are only deployed when pushed on the `master` branch.

I believe it's mostly complete, but it requires the configuration of a key to allow pushing back to the repository on the `gh-pages` branch.

@houqp To complete this, you'll just have to look at the last two sections (from Provisioning a Deploy Key):
https://circleci.com/blog/deploying-documentation-to-github-pages-with-continuous-integration/#provisioning-a-deploy-key (scroll up a little, the anchor is covered by the header)

I can't properly test this, sadly. But the implementation looks al right. You can continue on my branch with these last few changes if you desire before merging the request.