### PR TITLE
Update function for fallback resolution, mimick behavior of tesseract

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
           command: |
               echo 'deb http://deb.debian.org/debian stretch-backports main' | tee -a /etc/apt/sources.list
               apt-get update
-              apt-get -t stretch-backports -y install libleptonica-dev libtesseract-dev=4.0.0-2~bpo9+1 tesseract-ocr-eng clang
+              apt-get -t stretch-backports -y install libleptonica-dev libtesseract-dev=4.0.0-2~bpo9+1 tesseract-ocr-eng clang-7
       - run:
           name: Version information
           command: rustc --version; cargo --version; rustup --version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ documentation = "https://houqp.github.io/leptess/leptess/index.html"
 
 [dependencies]
 leptonica-sys = "0.2.0"
-tesseract-sys = "0.3.0"
+tesseract-sys = "0.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ pub struct LepTess {
 impl LepTess {
     pub fn new(data_path: Option<&str>, lang: &str) -> Result<LepTess, tesseract::TessInitError> {
         Ok(LepTess {
-            tess_api: tesseract::TessApi::new(data_path, lang)?
+            tess_api: tesseract::TessApi::new(data_path, lang)?,
         })
     }
 
@@ -125,7 +125,10 @@ impl LepTess {
 
     /// Override image resolution if not detected
     pub fn set_fallback_source_resolution(&mut self, res: i32) {
-        if self.get_source_y_resolution() <= 0 {
+        // TODO: fetch min (and max) resolution from C bindings
+        // TODO: only set resolution if user did not specify any explicitly
+        let resolution = self.get_source_y_resolution();
+        if resolution < 70 || resolution > 2400 {
             self.tess_api.set_source_resolution(res)
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,10 +125,10 @@ impl LepTess {
 
     /// Override image resolution if not detected
     pub fn set_fallback_source_resolution(&mut self, res: i32) {
-        // TODO: fetch min (and max) resolution from C bindings
-        // TODO: only set resolution if user did not specify any explicitly
         let resolution = self.get_source_y_resolution();
-        if resolution < 70 || resolution > 2400 {
+        if resolution < tesseract::MIN_CREDIBLE_RESOLUTION
+            || resolution > tesseract::MAX_CREDIBLE_RESOLUTION
+        {
             self.tess_api.set_source_resolution(res)
         }
     }

--- a/src/tesseract.rs
+++ b/src/tesseract.rs
@@ -7,6 +7,9 @@ use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 use std::ptr;
 
+pub use capi::kMaxCredibleResolution as MAX_CREDIBLE_RESOLUTION;
+pub use capi::kMinCredibleResolution as MIN_CREDIBLE_RESOLUTION;
+
 #[derive(Debug, PartialEq)]
 pub struct TessInitError {
     pub code: i32,


### PR DESCRIPTION
- [x] Fallback for all DPI values outside the allowed range, not just `0`.
- [x] Use DPI range constants through bindings, depends on https://github.com/antimatter15/tesseract-rs/issues/8
- [x] ~Only use fallback DPI if not explicitly specified~

This PR updates the behavior of the [`set_fallback_source_resolution`](https://houqp.github.io/leptess/leptess/struct.LepTess.html#method.set_fallback_source_resolution) function. It shouldn't only fallback if the DPI is 0, and it should only fallback if the user didn't explicitly specify a DPI.

More information: https://github.com/houqp/leptess/issues/6#issuecomment-541464674

Fixes #6 