### PR TITLE
Add LepTess::get_image_dimensions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,10 @@ impl LepTess {
         self.tess_api.get_source_y_resolution()
     }
 
+    pub fn get_image_dimensions(&self) -> Option<(u32, u32)> {
+        self.tess_api.get_image_dimensions()
+    }
+
     /// Override image resolution.
     /// Can be used to suppress "Warning: Invalid resolution 0 dpi." output.
     pub fn set_source_resolution(&mut self, res: i32) {

--- a/src/tesseract.rs
+++ b/src/tesseract.rs
@@ -75,8 +75,26 @@ impl TessApi {
         }
     }
 
+    /// Provide an image for Tesseract to recognize.
+    /// 
+    /// set_image clears all recognition results, and sets the rectangle to the full image, so it
+    /// may be followed immediately by a `[Self::get_utf8_text]`, and it will automatically perform
+    /// recognition. 
     pub fn set_image(&mut self, img: &leptonica::Pix) {
+        // "Tesseract takes its own copy of the image, so it need not persist until after Recognize"
         unsafe { capi::TessBaseAPISetImage2(self.raw, img.raw as *mut capi::Pix) }
+    }
+
+    // I have no idea if this is correct:
+    // - is TessBaseAPIGetInputImage the correct function to call? it's not documented at all
+    // - are .w and .h the correct attributes to check?
+    pub fn get_image_dimensions(&self) -> Option<(u32, u32)> {
+        unsafe {
+            let pix = capi::TessBaseAPIGetInputImage(self.raw);
+            if pix.is_null() { return None }
+
+            Some(((*pix).w as u32, (*pix).h as u32))
+        }
     }
 
     pub fn get_source_y_resolution(&mut self) -> i32 {

--- a/src/tesseract.rs
+++ b/src/tesseract.rs
@@ -84,10 +84,10 @@ impl TessApi {
         unsafe { capi::TessBaseAPISetImage2(self.raw, img.raw as *mut capi::Pix) }
     }
 
-    // I have no idea if this is correct:
-    // - is TessBaseAPIGetInputImage the correct function to call? it's not documented at all
-    // - are .w and .h the correct attributes to check?
     pub fn get_image_dimensions(&self) -> Option<(u32, u32)> {
+        // - is TessBaseAPIGetInputImage the correct function to call? it's not documented at all
+        // - are .w and .h the correct attributes to check?
+        // (probably)
         unsafe {
             let pix = capi::TessBaseAPIGetInputImage(self.raw);
             if pix.is_null() { return None }

--- a/src/tesseract.rs
+++ b/src/tesseract.rs
@@ -97,9 +97,6 @@ impl TessApi {
     /// assert_eq!(tes.get_image_dimensions(), Some((442, 852)));
     /// ```
     pub fn get_image_dimensions(&self) -> Option<(u32, u32)> {
-        // - is TessBaseAPIGetInputImage the correct function to call? it's not documented at all
-        // - are .w and .h the correct attributes to check?
-        // (probably)
         unsafe {
             let pix = capi::TessBaseAPIGetInputImage(self.raw);
             if pix.is_null() { return None }

--- a/src/tesseract.rs
+++ b/src/tesseract.rs
@@ -84,6 +84,18 @@ impl TessApi {
         unsafe { capi::TessBaseAPISetImage2(self.raw, img.raw as *mut capi::Pix) }
     }
 
+    /// Get the dimensions of the currently loaded image, or None if no image is loaded.
+    /// 
+    /// # Example
+    /// ```rust
+    /// let path = std::path::Path::new("tests/di.png");
+    /// let img = leptess::leptonica::pix_read(&path).unwrap();
+    /// 
+    /// let mut tes = leptess::tesseract::TessApi::new(Some("tests/tessdata"), "eng").unwrap();
+    /// tes.set_image(&img);
+    /// 
+    /// assert_eq!(tes.get_image_dimensions(), Some((442, 852)));
+    /// ```
     pub fn get_image_dimensions(&self) -> Option<(u32, u32)> {
         // - is TessBaseAPIGetInputImage the correct function to call? it's not documented at all
         // - are .w and .h the correct attributes to check?


### PR DESCRIPTION
Add a method `get_image_dimensions` to TessApi and LepTess, which returns a tuple with the currently loaded image's dimensions.