### PR TITLE
return error in pix read operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,6 @@ license = "MIT"
 documentation = "https://houqp.github.io/leptess/leptess/index.html"
 
 [dependencies]
-leptonica-sys = "0.3.1"
+leptonica-sys = "0.3.2"
 tesseract-sys = "0.5.2"
+thiserror = "1"

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+check:
+	cargo clippy
+	make test
+
 test:
 	cargo test
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,8 @@
 //! sudo apt-get install tesseract-ocr-eng
 //! ```
 
+extern crate thiserror;
+
 pub mod capi;
 pub mod leptonica;
 pub mod tesseract;
@@ -99,27 +101,17 @@ impl LepTess {
     }
 
     /// Set image to use for OCR.
-    pub fn set_image(&mut self, img_uri: impl AsRef<Path>) -> bool {
+    pub fn set_image(&mut self, img_uri: impl AsRef<Path>) -> Result<(), leptonica::PixError> {
         // TODO: support more uri scheme, default to file://
-        let re = leptonica::pix_read(img_uri.as_ref());
-
-        match re {
-            Some(pix) => {
-                self.tess_api.set_image(&pix);
-                true
-            }
-            None => false,
-        }
+        let pix = leptonica::pix_read(img_uri.as_ref())?;
+        self.tess_api.set_image(&pix);
+        Ok(())
     }
 
-    pub fn set_image_from_mem(&mut self, img: &[u8]) -> bool {
-        let result = leptonica::pix_read_mem(img);
-
-        if let Some(pix) = &result {
-            self.tess_api.set_image(&pix);
-        }
-
-        result.is_some()
+    pub fn set_image_from_mem(&mut self, img: &[u8]) -> Result<(), leptonica::PixError> {
+        let pix = leptonica::pix_read_mem(img)?;
+        self.tess_api.set_image(&pix);
+        Ok(())
     }
 
     pub fn get_source_y_resolution(&mut self) -> i32 {

--- a/tests/full_page_ocr.rs
+++ b/tests/full_page_ocr.rs
@@ -6,14 +6,14 @@ use std::path::Path;
 #[test]
 fn test_source_resolution() {
     let mut lt = LepTess::new(Some("./tests/tessdata"), "eng").unwrap();
-    assert_eq!(lt.set_image("./tests/di.png"), true);
+    lt.set_image("./tests/di.png").unwrap();
     assert_eq!(lt.get_source_y_resolution(), 0);
 }
 
 #[test]
 fn test_get_text() {
     let mut lt = LepTess::new(Some("./tests/tessdata"), "eng").unwrap();
-    assert_eq!(lt.set_image("./tests/di.png"), true);
+    lt.set_image("./tests/di.png").unwrap();
 
     let text = lt.get_utf8_text().unwrap();
 
@@ -31,7 +31,7 @@ fn test_get_text() {
 #[test]
 fn test_ocr_iterate_word() {
     let mut lt = LepTess::new(Some("./tests/tessdata"), "eng").unwrap();
-    assert_eq!(lt.set_image("./tests/di.png"), true);
+    lt.set_image("./tests/di.png").unwrap();
 
     let boxes = lt
         .get_component_boxes(leptess::capi::TessPageIteratorLevel_RIL_WORD, true)


### PR DESCRIPTION
After reading through the source code, I noticed leptonica actually returns null pointers to indicate errors, so we should return
a Result instead to keep the semantic consistent.

Also bumps version for leptonica-sys and fixes clippy error in master head.