### PR TITLE
Add hocr support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: rust:1.35-slim-stretch
+      - image: rust:1.49-slim-buster
     steps:
       - checkout
       - run:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptess"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["QP Hou <dave2008713@gmail.com>", "Chris Couzens <ccouzens@gmail.com>"]
 description = "Productive Rust binding for Tesseract and Leptonica."
 homepage = "https://github.com/houqp/leptess"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ pub mod capi;
 pub mod leptonica;
 pub mod tesseract;
 
+use std::os::raw::c_int;
 use std::path::Path;
 
 /// High level wrapper for Tesseract and Leptonica
@@ -160,6 +161,11 @@ impl LepTess {
     /// ```
     pub fn get_utf8_text(&self) -> Result<String, std::str::Utf8Error> {
         self.tess_api.get_utf8_text()
+    }
+
+    /// Extract text from image as HTML with bounding box attributes.
+    pub fn get_hocr_text(&self, page: c_int) -> Result<String, std::str::Utf8Error> {
+        self.tess_api.get_hocr_text(page)
     }
 
     pub fn mean_text_conf(&self) -> i32 {

--- a/tests/full_page_ocr.rs
+++ b/tests/full_page_ocr.rs
@@ -29,6 +29,17 @@ fn test_get_text() {
 }
 
 #[test]
+fn test_get_hocr_text() {
+    let mut lt = LepTess::new(Some("./tests/tessdata"), "eng").unwrap();
+    lt.set_image("./tests/di.png").unwrap();
+
+    let text = lt.get_hocr_text(0).unwrap();
+
+    assert!(text.contains("<div class='ocr_page'"));
+    assert!(text.contains("self-evident,"));
+}
+
+#[test]
 fn test_ocr_iterate_word() {
     let mut lt = LepTess::new(Some("./tests/tessdata"), "eng").unwrap();
     lt.set_image("./tests/di.png").unwrap();


### PR DESCRIPTION
HOCR presumably stands for HTML OCR. It generates HTML of the image,
with attributes describing where each word appears in the image.

https://github.com/houqp/leptess/issues/27

Example output (from different project):
https://github.com/antimatter15/tesseract-rs/blob/3edc4e7658a63aeefe371091e3133bcc24ec02f6/img.html