### PR TITLE
get_alto_text, get_tsv_text, get_lstm_box_text and get_word_str_box_text

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ documentation = "https://houqp.github.io/leptess/leptess/index.html"
 leptonica-sys = "0.3.2"
 tesseract-sys = "0.5.2"
 thiserror = "1"
+
+[dev-dependencies]
+regex = "1.4.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,27 @@ impl LepTess {
         self.tess_api.get_hocr_text(page)
     }
 
+    /// Extract text from image as XML-formatted string with Alto markup.
+    pub fn get_alto_text(&self, page: c_int) -> Result<String, std::str::Utf8Error> {
+        self.tess_api.get_alto_text(page)
+    }
+
+    /// Extract text from image as TSV-formatted string.
+    pub fn get_tsv_text(&self, page: c_int) -> Result<String, std::str::Utf8Error> {
+        self.tess_api.get_tsv_text(page)
+    }
+
+    /// Returns a box file for LSTM training from the internal data structures.
+    /// Constructs coordinates in the original image - not just the rectangle.
+    pub fn get_lstm_box_text(&self, page: c_int) -> Result<String, std::str::Utf8Error> {
+        self.tess_api.get_lstm_box_text(page)
+    }
+
+    /// Extract text from image as a string formatted in the same way as a Tesseract WordStr box file used in training.
+    pub fn get_word_str_box_text(&self, page: c_int) -> Result<String, std::str::Utf8Error> {
+        self.tess_api.get_word_str_box_text(page)
+    }
+
     pub fn mean_text_conf(&self) -> i32 {
         self.tess_api.mean_text_conf()
     }

--- a/src/tesseract.rs
+++ b/src/tesseract.rs
@@ -158,6 +158,54 @@ impl TessApi {
         }
     }
 
+    pub fn get_alto_text(&self, page: c_int) -> Result<String, std::str::Utf8Error> {
+        unsafe {
+            let sptr = capi::TessBaseAPIGetAltoText(self.raw, page);
+            let re = match CStr::from_ptr(sptr).to_str() {
+                Ok(s) => Ok(s.to_string()),
+                Err(e) => Err(e),
+            };
+            capi::TessDeleteText(sptr);
+            re
+        }
+    }
+
+    pub fn get_tsv_text(&self, page: c_int) -> Result<String, std::str::Utf8Error> {
+        unsafe {
+            let sptr = capi::TessBaseAPIGetTsvText(self.raw, page);
+            let re = match CStr::from_ptr(sptr).to_str() {
+                Ok(s) => Ok(s.to_string()),
+                Err(e) => Err(e),
+            };
+            capi::TessDeleteText(sptr);
+            re
+        }
+    }
+
+    pub fn get_lstm_box_text(&self, page: c_int) -> Result<String, std::str::Utf8Error> {
+        unsafe {
+            let sptr = capi::TessBaseAPIGetLSTMBoxText(self.raw, page);
+            let re = match CStr::from_ptr(sptr).to_str() {
+                Ok(s) => Ok(s.to_string()),
+                Err(e) => Err(e),
+            };
+            capi::TessDeleteText(sptr);
+            re
+        }
+    }
+
+    pub fn get_word_str_box_text(&self, page: c_int) -> Result<String, std::str::Utf8Error> {
+        unsafe {
+            let sptr = capi::TessBaseAPIGetWordStrBoxText(self.raw, page);
+            let re = match CStr::from_ptr(sptr).to_str() {
+                Ok(s) => Ok(s.to_string()),
+                Err(e) => Err(e),
+            };
+            capi::TessDeleteText(sptr);
+            re
+        }
+    }
+
     pub fn mean_text_conf(&self) -> i32 {
         unsafe { capi::TessBaseAPIMeanTextConf(self.raw) }
     }

--- a/tests/full_page_ocr.rs
+++ b/tests/full_page_ocr.rs
@@ -1,7 +1,9 @@
 extern crate leptess;
+extern crate regex;
 
 use leptess::{leptonica, tesseract, LepTess};
 use std::path::Path;
+use regex::Regex;
 
 #[test]
 fn test_source_resolution() {
@@ -32,11 +34,53 @@ fn test_get_text() {
 fn test_get_hocr_text() {
     let mut lt = LepTess::new(Some("./tests/tessdata"), "eng").unwrap();
     lt.set_image("./tests/di.png").unwrap();
-
     let text = lt.get_hocr_text(0).unwrap();
 
     assert!(text.contains("<div class='ocr_page'"));
     assert!(text.contains("self-evident,"));
+}
+
+#[test]
+fn test_get_alto_text() {
+    let mut lt = LepTess::new(Some("./tests/tessdata"), "eng").unwrap();
+    lt.set_image("./tests/di.png").unwrap();
+    let text = lt.get_alto_text(0).unwrap();
+    
+    let re = Regex::new(r#"<Page WIDTH="([0-9])+" HEIGHT="([0-9])+" PHYSICAL_IMG_NR="([0-9])+" ID="page_([0-9])+">"#).unwrap();
+    assert!(re.is_match(&text));
+    assert!(text.contains("CONTENT=\"Declaration\"/>"));
+}
+
+#[test]
+fn test_get_tsv_text() {
+    let mut lt = LepTess::new(Some("./tests/tessdata"), "eng").unwrap();
+    lt.set_image("./tests/di.png").unwrap();
+    let text = lt.get_tsv_text(0).unwrap();
+
+    let re = Regex::new(r"([-0-9]+\t){11}.*").unwrap();
+    assert!(re.is_match(&text));
+    assert!(text.contains("Declaration"));
+}
+
+#[test]
+fn test_get_lstm_box_text() {
+    let mut lt = LepTess::new(Some("./tests/tessdata"), "eng").unwrap();
+    lt.set_image("./tests/di.png").unwrap();
+    let text = lt.get_lstm_box_text(0).unwrap();
+
+    let re = Regex::new(r".?( [0-9]+){5}").unwrap();
+    assert!(re.is_match(&text));
+}
+
+#[test]
+fn test_get_word_str_box_text() {
+    let mut lt = LepTess::new(Some("./tests/tessdata"), "eng").unwrap();
+    lt.set_image("./tests/di.png").unwrap();
+    let text = lt.get_word_str_box_text(0).unwrap();
+
+    assert!(text.contains("WordStr"));
+    assert!(text.contains("becomes necessary for one people to"));
+    assert!(text.contains("to throw off such Government, and to provide new"));
 }
 
 #[test]


### PR DESCRIPTION
I've implemented get_alto_text, get_tsv_text, get_lstm_box_text and get_word_str_box_text, they work pretty much like get_hocr_text.
Also implemented tests for them, adding regex to dev-dependencies for testing of output formats.