### PR TITLE
New tesseract in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,16 +3,16 @@ version: 2
 jobs:
   test:
     docker:
-      - image: rust:1.49-alpine
+      - image: fedora:33
     steps:
       - checkout
       - run:
-          name: install leptonica & tesseract
+          name: install leptonica, tesseract and rust
           command: |
-              apk add --no-cache leptonica-dev tesseract-ocr-dev clang clang-libs libc-dev
+              dnf install -y rust clippy clang leptonica-devel tesseract-devel
       - run:
           name: Version information
-          command: rustc --version; cargo --version; rustup --version
+          command: rustc --version; cargo --version
       - run:
           name: Calculate dependencies
           command: cargo generate-lockfile
@@ -22,7 +22,6 @@ jobs:
       - run:
           name: lint code
           command: |
-              rustup component add clippy
               cargo clippy
       - run:
           name: Build all targets

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,13 @@ version: 2
 jobs:
   test:
     docker:
-      - image: rust:1.49-slim-buster
+      - image: rust:1.49-alpine
     steps:
       - checkout
       - run:
           name: install leptonica & tesseract
           command: |
-              echo 'deb http://deb.debian.org/debian stretch-backports main' | tee -a /etc/apt/sources.list
-              apt-get update
-              apt-get -t stretch-backports -y install libleptonica-dev libtesseract-dev=4.0.0-2~bpo9+1 tesseract-ocr-eng clang-7
+              apk add --no-cache leptonica-dev tesseract-ocr-dev clang clang-libs libc-dev
       - run:
           name: Version information
           command: rustc --version; cargo --version; rustup --version

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,8 +132,8 @@ impl LepTess {
     /// Override image resolution if not detected
     pub fn set_fallback_source_resolution(&mut self, res: i32) {
         let resolution = self.get_source_y_resolution();
-        if resolution < tesseract::MIN_CREDIBLE_RESOLUTION
-            || resolution > tesseract::MAX_CREDIBLE_RESOLUTION
+        if !(tesseract::MIN_CREDIBLE_RESOLUTION..=tesseract::MAX_CREDIBLE_RESOLUTION)
+            .contains(&resolution)
         {
             self.tess_api.set_source_resolution(res)
         }


### PR DESCRIPTION
We will want to have newer versions of tesseract within the CI tests.

Currently, any changes that use newer functions of tesseract (eg https://github.com/houqp/leptess/pull/29) fail the CI.

I tried using debian buster's version of tesseract- that was too old.
Then I tried using alpine, but that had issues with dynamically loading clang.

At this point, I stopped trying official rust images and went to fedora, which has everything new enough.