### PR TITLE
Switch to plumbing crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 documentation = "https://houqp.github.io/leptess/leptess/index.html"
 
 [dependencies]
-tesseract-plumbing = "0.4.0"
+tesseract-plumbing = "0.5.1"
 thiserror = "1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,7 @@ license = "MIT"
 documentation = "https://houqp.github.io/leptess/leptess/index.html"
 
 [dependencies]
-leptonica-sys = "0.3.2"
-tesseract-sys = "0.5.2"
+tesseract-plumbing = "0.4.0"
 thiserror = "1"
 
 [dev-dependencies]

--- a/examples/low_level_ocr_word_by_word.rs
+++ b/examples/low_level_ocr_word_by_word.rs
@@ -21,6 +21,6 @@ fn main() {
         api.set_rectangle(&b);
         let text = api.get_utf8_text().unwrap();
         let confi = api.mean_text_conf();
-        println!("{:?}, confidence: {}, text: {}", b.get_val(), confi, text);
+        println!("{:?}, confidence: {}, text: {}", b, confi, text);
     }
 }

--- a/examples/low_level_ocr_word_by_word.rs
+++ b/examples/low_level_ocr_word_by_word.rs
@@ -17,7 +17,7 @@ fn main() {
     println!("Found {} textline image components.", boxes.get_n());
 
     // run OCR on each word bounding box
-    for b in boxes {
+    for b in &boxes {
         api.set_rectangle(&b);
         let text = api.get_utf8_text().unwrap();
         let confi = api.mean_text_conf();

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -1,5 +1,4 @@
-extern crate leptonica_sys;
-extern crate tesseract_sys;
+extern crate tesseract_plumbing;
 
-pub use self::leptonica_sys::*;
-pub use self::tesseract_sys::*;
+pub use self::tesseract_plumbing::leptonica_sys::*;
+pub use self::tesseract_plumbing::tesseract_sys::*;

--- a/src/leptonica.rs
+++ b/src/leptonica.rs
@@ -109,6 +109,12 @@ impl<R: AsRef<leptonica_plumbing::leptonica_sys::Box>> AsRef<leptonica_plumbing:
     }
 }
 
+impl<R: AsRef<leptonica_plumbing::leptonica_sys::Box>> std::fmt::Debug for Box<R> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(self.as_ref(), f)
+    }
+}
+
 pub struct Boxa {
     pub raw: leptonica_plumbing::Boxa,
 }

--- a/src/leptonica.rs
+++ b/src/leptonica.rs
@@ -68,14 +68,6 @@ pub fn pix_read_mem(img: &[u8]) -> Result<Pix, PixError> {
     }
 }
 
-#[derive(Debug, PartialEq)]
-pub struct BoxVal {
-    pub x: i32,
-    pub y: i32,
-    pub w: i32,
-    pub h: i32,
-}
-
 pub struct Box<R: AsRef<leptonica_plumbing::leptonica_sys::Box>> {
     pub raw: R,
 }
@@ -85,18 +77,6 @@ impl Box<leptonica_plumbing::Box> {
         match leptonica_plumbing::Box::create_valid(x, y, width, height) {
             Err(leptonica_plumbing::BoxCreateValidError()) => None,
             Ok(raw) => Some(Box { raw }),
-        }
-    }
-}
-
-impl<R: AsRef<leptonica_plumbing::leptonica_sys::Box>> Box<R> {
-    pub fn get_val(&self) -> BoxVal {
-        let lbox: &leptonica_plumbing::leptonica_sys::Box = self.raw.as_ref();
-        BoxVal {
-            x: lbox.x,
-            y: lbox.y,
-            w: lbox.w,
-            h: lbox.h,
         }
     }
 }

--- a/src/leptonica.rs
+++ b/src/leptonica.rs
@@ -11,6 +11,8 @@ pub struct Pix {
     pub raw: leptonica_plumbing::Pix,
 }
 
+pub use self::leptonica_plumbing::Box;
+
 impl Pix {
     pub fn get_w(&self) -> u32 {
         let lpix: &leptonica_plumbing::leptonica_sys::Pix = self.raw.as_ref();
@@ -68,33 +70,6 @@ pub fn pix_read_mem(img: &[u8]) -> Result<Pix, PixError> {
     }
 }
 
-pub struct Box<R: AsRef<leptonica_plumbing::leptonica_sys::Box>> {
-    pub raw: R,
-}
-
-impl Box<leptonica_plumbing::Box> {
-    pub fn new(x: i32, y: i32, width: i32, height: i32) -> Option<Self> {
-        match leptonica_plumbing::Box::create_valid(x, y, width, height) {
-            Err(leptonica_plumbing::BoxCreateValidError()) => None,
-            Ok(raw) => Some(Box { raw }),
-        }
-    }
-}
-
-impl<R: AsRef<leptonica_plumbing::leptonica_sys::Box>> AsRef<leptonica_plumbing::leptonica_sys::Box>
-    for Box<R>
-{
-    fn as_ref(&self) -> &leptonica_plumbing::leptonica_sys::Box {
-        self.raw.as_ref()
-    }
-}
-
-impl<R: AsRef<leptonica_plumbing::leptonica_sys::Box>> std::fmt::Debug for Box<R> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Debug::fmt(self.as_ref(), f)
-    }
-}
-
 pub struct Boxa {
     pub raw: leptonica_plumbing::Boxa,
 }
@@ -105,14 +80,13 @@ impl Boxa {
         lboxa.n as usize
     }
 
-    pub fn get_box(&self, i: usize) -> Option<Box<leptonica_plumbing::BorrowedBox>> {
-        let raw = self.raw.get(std::convert::TryInto::try_into(i).ok()?)?;
-        Some(Box { raw })
+    pub fn get_box(&self, i: usize) -> Option<leptonica_plumbing::BorrowedBox> {
+        self.raw.get(std::convert::TryInto::try_into(i).ok()?)
     }
 }
 
 impl<'a> IntoIterator for &'a Boxa {
-    type Item = Box<leptonica_plumbing::BorrowedBox<'a>>;
+    type Item = leptonica_plumbing::BorrowedBox<'a>;
     type IntoIter = BoxaRefIterator<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -132,7 +106,7 @@ pub struct BoxaRefIterator<'a> {
 }
 
 impl<'a> Iterator for BoxaRefIterator<'a> {
-    type Item = Box<leptonica_plumbing::BorrowedBox<'a>>;
+    type Item = leptonica_plumbing::BorrowedBox<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.index >= self.count {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,7 @@ impl LepTess {
         }
     }
 
-    pub fn recognize(&self) -> i32 {
+    pub fn recognize(&mut self) -> i32 {
         self.tess_api.recognize()
     }
 
@@ -159,33 +159,33 @@ impl LepTess {
     /// lt.set_image("./tests/di.png");
     /// println!("{}", lt.get_utf8_text().unwrap());
     /// ```
-    pub fn get_utf8_text(&self) -> Result<String, std::str::Utf8Error> {
+    pub fn get_utf8_text(&mut self) -> Result<String, std::str::Utf8Error> {
         self.tess_api.get_utf8_text()
     }
 
     /// Extract text from image as HTML with bounding box attributes.
-    pub fn get_hocr_text(&self, page: c_int) -> Result<String, std::str::Utf8Error> {
+    pub fn get_hocr_text(&mut self, page: c_int) -> Result<String, std::str::Utf8Error> {
         self.tess_api.get_hocr_text(page)
     }
 
     /// Extract text from image as XML-formatted string with Alto markup.
-    pub fn get_alto_text(&self, page: c_int) -> Result<String, std::str::Utf8Error> {
+    pub fn get_alto_text(&mut self, page: c_int) -> Result<String, std::str::Utf8Error> {
         self.tess_api.get_alto_text(page)
     }
 
     /// Extract text from image as TSV-formatted string.
-    pub fn get_tsv_text(&self, page: c_int) -> Result<String, std::str::Utf8Error> {
+    pub fn get_tsv_text(&mut self, page: c_int) -> Result<String, std::str::Utf8Error> {
         self.tess_api.get_tsv_text(page)
     }
 
     /// Returns a box file for LSTM training from the internal data structures.
     /// Constructs coordinates in the original image - not just the rectangle.
-    pub fn get_lstm_box_text(&self, page: c_int) -> Result<String, std::str::Utf8Error> {
+    pub fn get_lstm_box_text(&mut self, page: c_int) -> Result<String, std::str::Utf8Error> {
         self.tess_api.get_lstm_box_text(page)
     }
 
     /// Extract text from image as a string formatted in the same way as a Tesseract WordStr box file used in training.
-    pub fn get_word_str_box_text(&self, page: c_int) -> Result<String, std::str::Utf8Error> {
+    pub fn get_word_str_box_text(&mut self, page: c_int) -> Result<String, std::str::Utf8Error> {
         self.tess_api.get_word_str_box_text(page)
     }
 
@@ -198,7 +198,7 @@ impl LepTess {
     }
 
     /// Get the given level kind of components (block, textline, word etc.) as a leptonica-style
-    /// Boxa, in reading order.If text_only is true, then only text components are returned.
+    /// Boxa, in reading order. If text_only is true, then only text components are returned.
     ///
     /// # Example
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@ impl LepTess {
     }
 
     /// Restrict OCR to a specific region of the image.
-    pub fn set_rectangle(&mut self, b: &leptonica::Box) {
+    pub fn set_rectangle(&mut self, b: impl AsRef<capi::Box>) {
         self.tess_api.set_rectangle(b)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ use std::path::Path;
 /// ).unwrap();
 ///
 /// for b in &boxes {
-///     println!("{:?}", b.get_val());
+///     println!("{:?}", b);
 /// }
 /// ```
 
@@ -213,7 +213,7 @@ impl LepTess {
     /// ).unwrap();
     ///
     /// for b in &boxes {
-    ///     println!("{:?}", b.get_val());
+    ///     println!("{:?}", b);
     /// }
     /// ```
     pub fn get_component_boxes(

--- a/src/tesseract.rs
+++ b/src/tesseract.rs
@@ -83,9 +83,9 @@ impl TessApi {
         }
     }
 
-    pub fn set_rectangle(&mut self, b: &leptonica::Box) {
-        let v = b.get_val();
-        self.raw.set_rectangle(v.x, v.y, v.w, v.h);
+    pub fn set_rectangle(&mut self, b: impl AsRef<crate::capi::Box>) {
+        let r = b.as_ref();
+        self.raw.set_rectangle(r.x, r.y, r.w, r.h);
     }
 
     pub fn get_utf8_text(&mut self) -> Result<String, std::str::Utf8Error> {

--- a/src/tesseract.rs
+++ b/src/tesseract.rs
@@ -1,77 +1,41 @@
 //! Low level wrapper for Tesseract C API
 
-use super::capi;
 use super::leptonica;
 use std::os::raw::c_int;
+use thiserror;
 
 use std::ffi::{CStr, CString};
-use std::os::raw::c_char;
-use std::ptr;
 
 pub use capi::kMaxCredibleResolution as MAX_CREDIBLE_RESOLUTION;
 pub use capi::kMinCredibleResolution as MIN_CREDIBLE_RESOLUTION;
+use capi::{TessPageIteratorLevel, TessPageIteratorLevel_RIL_BLOCK};
 
-#[derive(Debug, PartialEq)]
+#[derive(thiserror::Error, Debug, PartialEq)]
+#[error("TessInitError{{{}}}", .code)]
 pub struct TessInitError {
     pub code: i32,
 }
 
-impl std::error::Error for TessInitError {}
-
-impl std::fmt::Display for TessInitError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "TessInitError{{{}}}", self.code)
-    }
-}
-
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct TessApi {
-    pub raw: *mut capi::TessBaseAPI,
-    data_path_cptr: *mut c_char,
-}
-
-impl Drop for TessApi {
-    fn drop(&mut self) {
-        unsafe {
-            capi::TessBaseAPIEnd(self.raw);
-            capi::TessBaseAPIDelete(self.raw);
-
-            if !self.data_path_cptr.is_null() {
-                // free data_path_cptr, drop trait will take care of it
-                CString::from_raw(self.data_path_cptr);
-            }
-        }
-    }
+    pub raw: tesseract_plumbing::TessBaseApi,
 }
 
 impl TessApi {
     pub fn new<'a>(data_path: Option<&'a str>, lang: &'a str) -> Result<TessApi, TessInitError> {
-        let data_path_cptr;
-        let data_path_cstr;
+        let data_path_cstr = data_path.map(|dp| CString::new(dp).unwrap());
         let lang = CString::new(lang).unwrap();
-        match data_path {
-            Some(dstr) => {
-                data_path_cstr = CString::new(dstr).unwrap();
-                data_path_cptr = data_path_cstr.into_raw();
-            }
-            None => {
-                data_path_cptr = ptr::null_mut();
-            }
-        }
 
-        let api = TessApi {
-            raw: unsafe { capi::TessBaseAPICreate() },
-            data_path_cptr,
+        let mut api = TessApi {
+            raw: tesseract_plumbing::TessBaseApi::create(),
         };
 
-        unsafe {
-            let re = capi::TessBaseAPIInit3(api.raw, api.data_path_cptr, lang.as_ptr());
-
-            if re == 0 {
-                Ok(api)
-            } else {
-                Err(TessInitError { code: re })
-            }
+        match api
+            .raw
+            .init_2(data_path_cstr.as_deref(), Some(lang.as_ref()))
+        {
+            Err(tesseract_plumbing::TessBaseApiInitError()) => Err(TessInitError { code: -1 }),
+            Ok(()) => Ok(api),
         }
     }
 
@@ -81,8 +45,7 @@ impl TessApi {
     /// may be followed immediately by a `[Self::get_utf8_text]`, and it will automatically perform
     /// recognition.
     pub fn set_image(&mut self, img: &leptonica::Pix) {
-        // "Tesseract takes its own copy of the image, so it need not persist until after Recognize"
-        unsafe { capi::TessBaseAPISetImage2(self.raw, img.raw as *mut capi::Pix) }
+        self.raw.set_image_2(&img.raw)
     }
 
     /// Get the dimensions of the currently loaded image, or None if no image is loaded.
@@ -98,151 +61,108 @@ impl TessApi {
     /// assert_eq!(tes.get_image_dimensions(), Some((442, 852)));
     /// ```
     pub fn get_image_dimensions(&self) -> Option<(u32, u32)> {
-        unsafe {
-            let pix = capi::TessBaseAPIGetInputImage(self.raw);
-            if pix.is_null() {
-                return None;
-            }
-
-            Some(((*pix).w as u32, (*pix).h as u32))
-        }
+        let pix = self.raw.get_input_image()?;
+        let lpix: &tesseract_plumbing::leptonica_sys::Pix = pix.as_ref();
+        Some((lpix.w as u32, lpix.h as u32))
     }
 
-    pub fn get_source_y_resolution(&mut self) -> i32 {
-        unsafe { capi::TessBaseAPIGetSourceYResolution(self.raw) }
+    pub fn get_source_y_resolution(&self) -> i32 {
+        self.raw.get_source_y_resolution()
     }
 
     /// Override image resolution.
     /// Can be used to suppress "Warning: Invalid resolution 0 dpi." output.
     pub fn set_source_resolution(&mut self, res: i32) {
-        unsafe { capi::TessBaseAPISetSourceResolution(self.raw, res) }
+        self.raw.set_source_resolution(res)
     }
 
-    pub fn recognize(&self) -> i32 {
-        unsafe { capi::TessBaseAPIRecognize(self.raw, ptr::null_mut()) }
+    pub fn recognize(&mut self) -> i32 {
+        match self.raw.recognize() {
+            Ok(()) => 0,
+            Err(tesseract_plumbing::TessBaseApiRecogniseError()) => -1,
+        }
     }
 
     pub fn set_rectangle(&mut self, b: &leptonica::Box) {
         let v = b.get_val();
-        unsafe {
-            capi::TessBaseAPISetRectangle(self.raw, v.x, v.y, v.w, v.h);
+        self.raw.set_rectangle(v.x, v.y, v.w, v.h);
+    }
+
+    pub fn get_utf8_text(&mut self) -> Result<String, std::str::Utf8Error> {
+        let text = self.raw.get_utf8_text().unwrap();
+        let cstr: &CStr = text.as_ref();
+        match cstr.to_str() {
+            Ok(s) => Ok(s.to_string()),
+            Err(e) => Err(e),
         }
     }
 
-    pub fn get_utf8_text(&self) -> Result<String, std::str::Utf8Error> {
-        unsafe {
-            let re: Result<String, std::str::Utf8Error>;
-            let sptr = capi::TessBaseAPIGetUTF8Text(self.raw);
-            match CStr::from_ptr(sptr).to_str() {
-                Ok(s) => {
-                    re = Ok(s.to_string());
-                }
-                Err(e) => {
-                    re = Err(e);
-                }
-            }
-            capi::TessDeleteText(sptr);
-            re
+    pub fn get_hocr_text(&mut self, page: c_int) -> Result<String, std::str::Utf8Error> {
+        let text = self.raw.get_hocr_text(page).unwrap();
+        let cstr: &CStr = text.as_ref();
+        match cstr.to_str() {
+            Ok(s) => Ok(s.to_string()),
+            Err(e) => Err(e),
         }
     }
 
-    pub fn get_hocr_text(&self, page: c_int) -> Result<String, std::str::Utf8Error> {
-        unsafe {
-            let sptr = capi::TessBaseAPIGetHOCRText(self.raw, page);
-            let re = match CStr::from_ptr(sptr).to_str() {
-                Ok(s) => Ok(s.to_string()),
-                Err(e) => Err(e),
-            };
-            capi::TessDeleteText(sptr);
-            re
+    pub fn get_alto_text(&mut self, page: c_int) -> Result<String, std::str::Utf8Error> {
+        let text = self.raw.get_alto_text(page).unwrap();
+        let cstr: &CStr = text.as_ref();
+        match cstr.to_str() {
+            Ok(s) => Ok(s.to_string()),
+            Err(e) => Err(e),
         }
     }
 
-    pub fn get_alto_text(&self, page: c_int) -> Result<String, std::str::Utf8Error> {
-        unsafe {
-            let sptr = capi::TessBaseAPIGetAltoText(self.raw, page);
-            let re = match CStr::from_ptr(sptr).to_str() {
-                Ok(s) => Ok(s.to_string()),
-                Err(e) => Err(e),
-            };
-            capi::TessDeleteText(sptr);
-            re
+    pub fn get_tsv_text(&mut self, page: c_int) -> Result<String, std::str::Utf8Error> {
+        let text = self.raw.get_tsv_text(page).unwrap();
+        let cstr: &CStr = text.as_ref();
+        match cstr.to_str() {
+            Ok(s) => Ok(s.to_string()),
+            Err(e) => Err(e),
         }
     }
 
-    pub fn get_tsv_text(&self, page: c_int) -> Result<String, std::str::Utf8Error> {
-        unsafe {
-            let sptr = capi::TessBaseAPIGetTsvText(self.raw, page);
-            let re = match CStr::from_ptr(sptr).to_str() {
-                Ok(s) => Ok(s.to_string()),
-                Err(e) => Err(e),
-            };
-            capi::TessDeleteText(sptr);
-            re
+    pub fn get_lstm_box_text(&mut self, page: c_int) -> Result<String, std::str::Utf8Error> {
+        let text = self.raw.get_lstm_box_text(page).unwrap();
+        let cstr: &CStr = text.as_ref();
+        match cstr.to_str() {
+            Ok(s) => Ok(s.to_string()),
+            Err(e) => Err(e),
         }
     }
 
-    pub fn get_lstm_box_text(&self, page: c_int) -> Result<String, std::str::Utf8Error> {
-        unsafe {
-            let sptr = capi::TessBaseAPIGetLSTMBoxText(self.raw, page);
-            let re = match CStr::from_ptr(sptr).to_str() {
-                Ok(s) => Ok(s.to_string()),
-                Err(e) => Err(e),
-            };
-            capi::TessDeleteText(sptr);
-            re
-        }
-    }
-
-    pub fn get_word_str_box_text(&self, page: c_int) -> Result<String, std::str::Utf8Error> {
-        unsafe {
-            let sptr = capi::TessBaseAPIGetWordStrBoxText(self.raw, page);
-            let re = match CStr::from_ptr(sptr).to_str() {
-                Ok(s) => Ok(s.to_string()),
-                Err(e) => Err(e),
-            };
-            capi::TessDeleteText(sptr);
-            re
+    pub fn get_word_str_box_text(&mut self, page: c_int) -> Result<String, std::str::Utf8Error> {
+        let text = self.raw.get_word_str_box_text(page).unwrap();
+        let cstr: &CStr = text.as_ref();
+        match cstr.to_str() {
+            Ok(s) => Ok(s.to_string()),
+            Err(e) => Err(e),
         }
     }
 
     pub fn mean_text_conf(&self) -> i32 {
-        unsafe { capi::TessBaseAPIMeanTextConf(self.raw) }
+        self.raw.mean_text_conf()
     }
 
     pub fn get_regions(&self) -> Option<leptonica::Boxa> {
-        unsafe {
-            let boxes = capi::TessBaseAPIGetRegions(self.raw, ptr::null_mut());
-            if boxes.is_null() {
-                None
-            } else {
-                Some(leptonica::Boxa { raw: boxes })
-            }
-        }
+        self.get_component_images(TessPageIteratorLevel_RIL_BLOCK, false)
     }
 
     /// Get the given level kind of components (block, textline, word etc.) as a leptonica-style
     /// Boxa, in reading order.If text_only is true, then only text components are returned.
     pub fn get_component_images(
         &self,
-        level: capi::TessPageIteratorLevel,
+        level: TessPageIteratorLevel,
         text_only: bool,
     ) -> Option<leptonica::Boxa> {
-        let text_only_val: i32 = if text_only { 1 } else { 0 };
-        unsafe {
-            let boxes = capi::TessBaseAPIGetComponentImages(
-                self.raw,
-                level,
-                text_only_val,
-                ptr::null_mut(),
-                ptr::null_mut(),
-            );
-
-            if boxes.is_null() {
-                None
-            } else {
-                Some(leptonica::Boxa { raw: boxes })
-            }
+        match self
+            .raw
+            .get_component_images_1(level, if text_only { 1 } else { 0 })
+        {
+            Ok(boxa) => Some(leptonica::Boxa { raw: boxa }),
+            Err(_) => None,
         }
     }
 }

--- a/tests/full_page_ocr.rs
+++ b/tests/full_page_ocr.rs
@@ -2,8 +2,8 @@ extern crate leptess;
 extern crate regex;
 
 use leptess::{leptonica, tesseract, LepTess};
-use std::path::Path;
 use regex::Regex;
+use std::path::Path;
 
 #[test]
 fn test_source_resolution() {
@@ -45,7 +45,7 @@ fn test_get_alto_text() {
     let mut lt = LepTess::new(Some("./tests/tessdata"), "eng").unwrap();
     lt.set_image("./tests/di.png").unwrap();
     let text = lt.get_alto_text(0).unwrap();
-    
+
     let re = Regex::new(r#"<Page WIDTH="([0-9])+" HEIGHT="([0-9])+" PHYSICAL_IMG_NR="([0-9])+" ID="page_([0-9])+">"#).unwrap();
     assert!(re.is_match(&text));
     assert!(text.contains("CONTENT=\"Declaration\"/>"));
@@ -184,7 +184,7 @@ fn test_low_lvl_ocr_iterate_word() {
 #[test]
 fn test_low_lvl_invalid_data_path() {
     let re = tesseract::TessApi::new(Some("tests_foo"), "eng");
-    assert_eq!(Err(tesseract::TessInitError { code: -1 }), re);
+    assert_eq!(Some(tesseract::TessInitError { code: -1 }), re.err());
 }
 
 #[cfg(not(windows))]

--- a/tests/full_page_ocr.rs
+++ b/tests/full_page_ocr.rs
@@ -97,13 +97,8 @@ fn test_ocr_iterate_word() {
         let text = lt.get_utf8_text().unwrap();
 
         assert_eq!(
-            leptonica::BoxVal {
-                x: 118,
-                y: 5,
-                w: 17,
-                h: 11,
-            },
-            b.get_val()
+            (118, 5, 17, 11),
+            (b.as_ref().x, b.as_ref().y, b.as_ref().w, b.as_ref().h)
         );
         assert_eq!("IN\n", text);
 
@@ -158,13 +153,8 @@ fn test_low_lvl_ocr_iterate_word() {
         let text = api.get_utf8_text().unwrap();
 
         assert_eq!(
-            leptonica::BoxVal {
-                x: 118,
-                y: 5,
-                w: 17,
-                h: 11,
-            },
-            b.get_val()
+            (118, 5, 17, 11),
+            (b.as_ref().x, b.as_ref().y, b.as_ref().w, b.as_ref().h)
         );
         assert_eq!("IN\n", text);
 


### PR DESCRIPTION
# Switch to being based off the plumbing crate

```
git diff origin/HEAD --stat
 Cargo.toml                             |   3 +-
 examples/low_level_ocr_word_by_word.rs |   4 +-
 src/capi.rs                            |   7 +-
 src/leptonica.rs                       | 170 +++++++++-----------------------
 src/lib.rs                             |  22 ++---
 src/tesseract.rs                       | 230 ++++++++++++++-----------------------------
 tests/full_page_ocr.rs                 |  24 ++---
 7 files changed, 143 insertions(+), 317 deletions(-)
```

by switching to being built on the plumbing crate, we
1. Remove a lot of code from leptess
2. Remove the `unsafe` keyword from leptess
3. Will more quickly be able to roll out new features like `setvariable`

There are some small changes to the API, mostly around some methods now requiring `mut`. As this isn't yet version 1.0.0, semantic versioning will allow us to break the API. But maybe once this is merged and the next few feature requests are dealt with, it will be time to have the version 1.0.0 release.

The other major API change is around leptonica's Box. I think it was previously sometimes incorrectly wrapping the struct when it only had a borrowed reference (the issue being the drop trait might have freed it prematurely). I've introduced a `BorrowedBox` in leptonica-plumbing, and made leptess's Box struct generic over the two types.

The examples and the tests barely changing show that the API changes are minor.

https://github.com/houqp/leptess/issues/34