### PR TITLE
Document using the image crate to load images

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptess"
-version = "0.13.2"
+version = "0.13.3"
 authors = ["QP Hou <dave2008713@gmail.com>", "Chris Couzens <ccouzens@gmail.com>"]
 description = "Productive Rust binding for Tesseract and Leptonica."
 homepage = "https://github.com/houqp/leptess"
@@ -15,4 +15,5 @@ tesseract-plumbing = "~0.6"
 thiserror = "1"
 
 [dev-dependencies]
+image = "0.24.2"
 regex = "1.4.3"

--- a/README.md
+++ b/README.md
@@ -73,6 +73,6 @@ cargo run --example low_level_ocr_full_page
 
 ## Development
 
-To run tests, you will need at Tesseract 4.x to match what we have in
-`tests/tessdata/eng.traineddata`. See CircleCI config to see how to replicate
+To run tests, you will need at Tesseract 4.x or 5.x to match what we have in
+`tests/tessdata/eng.traineddata`. See GitHub config actions to see how to replicate
 the setup.

--- a/examples/set_from_image_crate.rs
+++ b/examples/set_from_image_crate.rs
@@ -1,0 +1,21 @@
+extern crate image;
+extern crate leptess;
+
+use std::io::Cursor;
+
+use leptess::LepTess;
+
+fn main() {
+    let img = image::open("./tests/di.png").unwrap();
+    let mut tiff_buffer = Vec::new();
+    img.write_to(
+        &mut Cursor::new(&mut tiff_buffer),
+        image::ImageOutputFormat::Tiff,
+    )
+    .unwrap();
+
+    let mut lt = LepTess::new(Some("./tests/tessdata"), "eng").unwrap();
+
+    lt.set_image_from_mem(&tiff_buffer).unwrap();
+    println!("{}", lt.get_utf8_text().unwrap());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,9 @@ impl LepTess {
         Ok(())
     }
 
+    /// Set the source image from an in-memory file
+    ///
+    /// Only tiff files are supported from windows. More file formats are supported from other operating systems
     pub fn set_image_from_mem(&mut self, img: &[u8]) -> Result<(), leptonica::PixError> {
         let pix = leptonica::pix_read_mem(img)?;
         self.tess_api.set_image(&pix);

--- a/tests/image_crate.rs
+++ b/tests/image_crate.rs
@@ -1,0 +1,33 @@
+extern crate image;
+extern crate leptess;
+
+use std::io::Cursor;
+
+use leptess::LepTess;
+
+#[test]
+fn test_read_pix() {
+    let img = image::open("./tests/di.png").unwrap();
+    let mut tiff_buffer = Vec::new();
+    img.write_to(
+        &mut Cursor::new(&mut tiff_buffer),
+        image::ImageOutputFormat::Tiff,
+    )
+    .unwrap();
+
+    let mut lt = LepTess::new(Some("./tests/tessdata"), "eng").unwrap();
+
+    lt.set_image_from_mem(&tiff_buffer).unwrap();
+
+    let text = lt.get_utf8_text().unwrap();
+
+    let mut lines = text.lines();
+    assert_eq!(
+        "We hold these truths to be self-evident, that all men",
+        lines.nth(14).unwrap()
+    );
+    assert_eq!(
+        "are created equal, that they are endowed by their",
+        lines.nth(0).unwrap()
+    );
+}


### PR DESCRIPTION
My comment about tiff and windows is because of this documentation
https://tpgit.github.io/Leptonica/leptprotos_8h.html#a027a927dc3438192e3bdae8c219d7f6a

> On windows, this will only read tiff formatted files from memory. For other formats, it requires fmemopen(3). Attempts to read those formats will fail at runtime. (3)

Whilst it won't resolve the issue, this is my first step at tackling
https://github.com/houqp/leptess/issues/43. The next step will be to add
and use the leptonica methods that support tiff from disk and `PixA`.