### PR TITLE
Use newer version of tesseract-plumbing (ver. ~0.7)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptess"
-version = "0.13.3"
+version = "0.13.4"
 authors = ["QP Hou <dave2008713@gmail.com>", "Chris Couzens <ccouzens@gmail.com>"]
 description = "Productive Rust binding for Tesseract and Leptonica."
 homepage = "https://github.com/houqp/leptess"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 documentation = "https://houqp.github.io/leptess/leptess/index.html"
 
 [dependencies]
-tesseract-plumbing = "~0.6"
+tesseract-plumbing = "~0.7"
 thiserror = "1"
 
 [dev-dependencies]


### PR DESCRIPTION
Update tesseract-plumbing to `~0.7`

To support latest 0.7.1 release of https://github.com/ccouzens/tesseract-plumbing