### PR TITLE
Leptonica 1.83.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptess"
-version = "0.13.4"
+version = "0.14.0"
 authors = ["QP Hou <dave2008713@gmail.com>", "Chris Couzens <ccouzens@gmail.com>"]
 description = "Productive Rust binding for Tesseract and Leptonica."
 homepage = "https://github.com/houqp/leptess"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 documentation = "https://houqp.github.io/leptess/leptess/index.html"
 
 [dependencies]
-tesseract-plumbing = { path = "../../ccouzens/tesseract-plumbing" }
+tesseract-plumbing = "~0.8"
 thiserror = "1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 documentation = "https://houqp.github.io/leptess/leptess/index.html"
 
 [dependencies]
-tesseract-plumbing = "~0.7"
+tesseract-plumbing = { path = "../../ccouzens/tesseract-plumbing" }
 thiserror = "1"
 
 [dev-dependencies]

--- a/examples/low_level_ocr_word_by_word.rs
+++ b/examples/low_level_ocr_word_by_word.rs
@@ -18,7 +18,7 @@ fn main() {
 
     // run OCR on each word bounding box
     for b in &boxes {
-        api.set_rectangle(&b);
+        api.set_rectangle_from_box(&b);
         let text = api.get_utf8_text().unwrap();
         let confi = api.mean_text_conf();
         println!("{:?}, confidence: {}, text: {}", b, confi, text);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,9 +73,7 @@ pub use variable::Variable;
 /// ```
 /// # let mut lt = leptess::LepTess::new(Some("./tests/tessdata"), "eng").unwrap();
 /// # lt.set_image("./tests/di.png");
-/// lt.set_rectangle(&leptess::leptonica::Box::new(
-///     10, 10, 200, 60,
-/// ).unwrap());
+/// lt.set_rectangle(10, 10, 200, 60);
 /// println!("{}", lt.get_utf8_text().unwrap());
 /// ```
 ///
@@ -151,8 +149,13 @@ impl LepTess {
     }
 
     /// Restrict OCR to a specific region of the image.
-    pub fn set_rectangle(&mut self, b: impl AsRef<capi::Box>) {
-        self.tess_api.set_rectangle(b)
+    pub fn set_rectangle(&mut self, left: i32, top: i32, width: i32, height: i32) {
+        self.tess_api.set_rectangle(left, top, width, height)
+    }
+
+    /// Restrict OCR to a specific region of the image using a leptonica Box struct.
+    pub fn set_rectangle_from_box(&mut self, b: &leptonica::Box) {
+        self.tess_api.set_rectangle_from_box(b)
     }
 
     /// Extract text from current selected region of the image. By default, it is the full page.

--- a/src/tesseract.rs
+++ b/src/tesseract.rs
@@ -1,5 +1,7 @@
 //! Low level wrapper for Tesseract C API
 
+use crate::leptonica::BoxGeometry;
+
 use super::leptonica;
 use std::os::raw::c_int;
 use thiserror;
@@ -66,8 +68,7 @@ impl TessApi {
     /// ```
     pub fn get_image_dimensions(&self) -> Option<(u32, u32)> {
         let pix = self.raw.get_input_image()?;
-        let lpix: &tesseract_plumbing::leptonica_sys::Pix = pix.as_ref();
-        Some((lpix.w as u32, lpix.h as u32))
+        Some((pix.get_width() as u32, pix.get_height() as u32))
     }
 
     pub fn get_source_y_resolution(&self) -> i32 {
@@ -87,9 +88,13 @@ impl TessApi {
         }
     }
 
-    pub fn set_rectangle(&mut self, b: impl AsRef<crate::capi::Box>) {
-        let r = b.as_ref();
-        self.raw.set_rectangle(r.x, r.y, r.w, r.h);
+    pub fn set_rectangle(&mut self, left: i32, top: i32, width: i32, height: i32) {
+        self.raw.set_rectangle(left, top, width, height);
+    }
+
+    pub fn set_rectangle_from_box(&mut self, b: &leptonica::Box) {
+        let BoxGeometry { x, y, w, h } = b.get_geometry();
+        self.set_rectangle(x, y, w, h);
     }
 
     pub fn get_utf8_text(&mut self) -> Result<String, std::str::Utf8Error> {

--- a/tests/full_page_ocr.rs
+++ b/tests/full_page_ocr.rs
@@ -1,7 +1,10 @@
 extern crate leptess;
 extern crate regex;
 
-use leptess::{leptonica, tesseract, LepTess, Variable};
+use leptess::{
+    leptonica::{self, BoxGeometry},
+    tesseract, LepTess, Variable,
+};
 use regex::Regex;
 use std::path::Path;
 
@@ -93,12 +96,17 @@ fn test_ocr_iterate_word() {
         .unwrap();
 
     for b in &boxes {
-        lt.set_rectangle(&b);
+        lt.set_rectangle_from_box(&b);
         let text = lt.get_utf8_text().unwrap();
 
         assert_eq!(
-            (118, 5, 17, 11),
-            (b.as_ref().x, b.as_ref().y, b.as_ref().w, b.as_ref().h)
+            BoxGeometry {
+                x: 118,
+                y: 5,
+                w: 17,
+                h: 11
+            },
+            b.get_geometry()
         );
         assert_eq!("IN\n", text);
 
@@ -107,11 +115,11 @@ fn test_ocr_iterate_word() {
 
     let mut iter = boxes.into_iter();
     let b = iter.nth(5).unwrap();
-    lt.set_rectangle(&b);
+    lt.set_rectangle_from_box(&b);
     assert_eq!("The unanimous Declaration\n", lt.get_utf8_text().unwrap());
 
     let b = iter.nth(14).unwrap();
-    lt.set_rectangle(&b);
+    lt.set_rectangle_from_box(&b);
     assert_eq!("people\n", lt.get_utf8_text().unwrap());
 }
 
@@ -149,12 +157,17 @@ fn test_low_lvl_ocr_iterate_word() {
         .unwrap();
 
     for b in &boxes {
-        api.set_rectangle(&b);
+        api.set_rectangle_from_box(&b);
         let text = api.get_utf8_text().unwrap();
 
         assert_eq!(
-            (118, 5, 17, 11),
-            (b.as_ref().x, b.as_ref().y, b.as_ref().w, b.as_ref().h)
+            BoxGeometry {
+                x: 118,
+                y: 5,
+                w: 17,
+                h: 11
+            },
+            b.get_geometry()
         );
         assert_eq!("IN\n", text);
 
@@ -163,11 +176,11 @@ fn test_low_lvl_ocr_iterate_word() {
 
     let mut iter = boxes.into_iter();
     let b = iter.nth(5).unwrap();
-    api.set_rectangle(&b);
+    api.set_rectangle_from_box(&b);
     assert_eq!("The unanimous Declaration\n", api.get_utf8_text().unwrap());
 
     let b = iter.nth(14).unwrap();
-    api.set_rectangle(&b);
+    api.set_rectangle_from_box(&b);
     assert_eq!("people\n", api.get_utf8_text().unwrap());
 }
 


### PR DESCRIPTION
Make changes to support leptonica 1.83.0

https://github.com/ccouzens/leptonica-plumbing/issues/5

Basically leptonica made the fields within its structs private. Which means we can only get go them via leptonica's methods.

In the case of pixa and boxa, it required bigger changes as we could no longer get to their items directly. When going through leptonica's methods, we no longer merely borrow the memory, but get a reference counted copy. This requires us to handle it differently (eg dropping it afterwards).