### PR TITLE
Create an example of using with leptonica's c-api

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,10 @@ jobs:
       run: sudo apt-get install libleptonica-dev libtesseract-dev clang tesseract-ocr-eng
     - uses: actions/checkout@v2
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --verbose --no-default-features
     - name: Lint code
-      run: cargo clippy
+      run: cargo clippy --no-default-features
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose --no-default-features
     - name: Check formatting
       run: cargo fmt -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://houqp.github.io/leptess/leptess/index.html"
 [dependencies]
 tesseract-plumbing = "~0.11"
 thiserror = "1"
+leptonica-plumbing = "~1.3.0"
 
 [dev-dependencies]
 image = "0.24.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 documentation = "https://houqp.github.io/leptess/leptess/index.html"
 
 [dependencies]
-tesseract-plumbing = "~0.11"
+tesseract-plumbing = {version = "~0.11", default-features = false}
 thiserror = "1"
 leptonica-plumbing = "~1.3.0"
 

--- a/examples/with_leptonica_c_api.rs
+++ b/examples/with_leptonica_c_api.rs
@@ -1,0 +1,19 @@
+extern crate leptess;
+
+use leptess::{capi, tesseract};
+use std::ffi::CString;
+
+fn main() {
+    let tessdata_path = Some("./tests/tessdata");
+    let mut api = tesseract::TessApi::new(tessdata_path, "eng").unwrap();
+
+    let image_path = CString::new("./tests/di.png").unwrap();
+    let mut pix = leptonica_plumbing::Pix::read(&image_path).unwrap();
+
+    let pix_scaled_c = unsafe { capi::pixScaleSmooth(pix.as_mut(), 2.0, 2.0).as_mut() }
+        .expect("pointer should not be null");
+    let pix_scaled_safe = unsafe { leptonica_plumbing::Pix::new_from_pointer(pix_scaled_c) };
+    api.set_image(&pix_scaled_safe);
+
+    println!("Text: {}", api.get_utf8_text().unwrap());
+}

--- a/src/leptonica.rs
+++ b/src/leptonica.rs
@@ -23,6 +23,12 @@ impl Pix {
     }
 }
 
+impl AsRef<leptonica_plumbing::Pix> for Pix {
+    fn as_ref(&self) -> &leptonica_plumbing::Pix {
+        &self.raw
+    }
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum PixError {
     #[error("Failed to read image from {}", .0)]

--- a/src/tesseract.rs
+++ b/src/tesseract.rs
@@ -51,7 +51,7 @@ impl TessApi {
     /// may be followed immediately by a `[Self::get_utf8_text]`, and it will automatically perform
     /// recognition.
     pub fn set_image(&mut self, img: impl AsRef<tesseract_plumbing::leptonica_plumbing::Pix>) {
-        self.raw.set_image_2(&img.as_ref())
+        self.raw.set_image_2(img.as_ref())
     }
 
     /// Get the dimensions of the currently loaded image, or None if no image is loaded.

--- a/src/tesseract.rs
+++ b/src/tesseract.rs
@@ -50,8 +50,8 @@ impl TessApi {
     /// set_image clears all recognition results, and sets the rectangle to the full image, so it
     /// may be followed immediately by a `[Self::get_utf8_text]`, and it will automatically perform
     /// recognition.
-    pub fn set_image(&mut self, img: &leptonica::Pix) {
-        self.raw.set_image_2(&img.raw)
+    pub fn set_image(&mut self, img: impl AsRef<tesseract_plumbing::leptonica_plumbing::Pix>) {
+        self.raw.set_image_2(&img.as_ref())
     }
 
     /// Get the dimensions of the currently loaded image, or None if no image is loaded.


### PR DESCRIPTION
It needed support to be able to get the mut pointer from leptonica-plumbing

https://github.com/ccouzens/leptonica-plumbing/commit/4a721e7eb107e0af634d4f3d1218a441f2ad729a

And for leptonica-plumbing pix to self reference

https://github.com/ccouzens/leptonica-plumbing/commit/545708cf8fc3da070852bd4a1f008324fd1a562b

It uses this so that methods can take AsRef<LeptonicaPlumbing::Pix> which both leptess and leptonica-plumbing satisfy.

Addresses https://github.com/houqp/leptess/issues/59